### PR TITLE
fix: check production build based on context only

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ export const onSuccess = async (props) => {
   };
 
   // Only run on production builds
-  if (constants.IS_LOCAL || CONTEXT !== "production") {
+  if (CONTEXT !== "production") {
     console.log(
       `Skip submitting sitemap to ${providers.join(
         ", "


### PR DESCRIPTION
constants.IS_LOCAL shouldn't be considered in checking production builds as it returns true when site is deployed from environments other than netlify (eg. using netlify deploy within github workflow).